### PR TITLE
Add pwd

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,39 @@
+module.exports = {
+  /**
+   * The root of your source code, typically /src
+   * `<rootDir>` is a token Jest substitutes
+   */
+  roots: ['<rootDir>/src'],
+
+  /**
+   * Jest transformations -- this adds support for TypeScript
+   * using ts-jest
+   */
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest',
+  },
+
+  /**
+   * Runs special logic (immediately after test framework installed in environment),
+   * such as cleaning up components when using React Testing Library
+   * and adds special extended assertions to Jest
+   */
+  setupFilesAfterEnv: [
+    '@testing-library/react/cleanup-after-each',
+    '@testing-library/jest-dom/extend-expect',
+  ],
+
+  moduleNameWrapper: {
+    electron: '<rootDir>/src/__mocks__/electron.js',
+  },
+
+  /**
+   * Test spec file resolution pattern
+   * Matches parent folder `__tests__` and filename
+   * should contain `test` or `spec`.
+   */
+  testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$',
+
+  // Module file extensions for importing
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1103,48 +1103,6 @@
         "slash": "2.0.0"
       }
     },
-    "@jest/core": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-24.9.0.tgz",
-      "integrity": "sha512-Fogg3s4wlAr1VX7q+rhV9RVnUv5tD7VuWfYy1+whMiWUrvl7U3QJSJyWcDio9Lq2prqYsZaeTv2Rz24pWGkJ2A==",
-      "requires": {
-        "@jest/console": "24.9.0",
-        "@jest/reporters": "24.9.0",
-        "@jest/test-result": "24.9.0",
-        "@jest/transform": "24.9.0",
-        "@jest/types": "24.9.0",
-        "ansi-escapes": "3.2.0",
-        "chalk": "2.4.2",
-        "exit": "0.1.2",
-        "graceful-fs": "4.2.3",
-        "jest-changed-files": "24.9.0",
-        "jest-config": "24.9.0",
-        "jest-haste-map": "24.9.0",
-        "jest-message-util": "24.9.0",
-        "jest-regex-util": "24.9.0",
-        "jest-resolve": "24.9.0",
-        "jest-resolve-dependencies": "24.9.0",
-        "jest-runner": "24.9.0",
-        "jest-runtime": "24.9.0",
-        "jest-snapshot": "24.9.0",
-        "jest-util": "24.9.0",
-        "jest-validate": "24.9.0",
-        "jest-watcher": "24.9.0",
-        "micromatch": "3.1.10",
-        "p-each-series": "1.0.0",
-        "realpath-native": "1.1.0",
-        "rimraf": "2.6.3",
-        "slash": "2.0.0",
-        "strip-ansi": "5.2.0"
-      },
-      "dependencies": {
-        "ansi-escapes": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-          "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
-        }
-      }
-    },
     "@jest/environment": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.9.0.tgz",
@@ -1166,34 +1124,6 @@
         "jest-mock": "24.9.0"
       }
     },
-    "@jest/reporters": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.9.0.tgz",
-      "integrity": "sha512-mu4X0yjaHrffOsWmVLzitKmmmWSQ3GGuefgNscUSWNiUNcEOSEQk9k3pERKEQVBb0Cnn88+UESIsZEMH3o88Gw==",
-      "requires": {
-        "@jest/environment": "24.9.0",
-        "@jest/test-result": "24.9.0",
-        "@jest/transform": "24.9.0",
-        "@jest/types": "24.9.0",
-        "chalk": "2.4.2",
-        "exit": "0.1.2",
-        "glob": "7.1.6",
-        "istanbul-lib-coverage": "2.0.5",
-        "istanbul-lib-instrument": "3.3.0",
-        "istanbul-lib-report": "2.0.8",
-        "istanbul-lib-source-maps": "3.0.6",
-        "istanbul-reports": "2.2.7",
-        "jest-haste-map": "24.9.0",
-        "jest-resolve": "24.9.0",
-        "jest-runtime": "24.9.0",
-        "jest-util": "24.9.0",
-        "jest-worker": "24.9.0",
-        "node-notifier": "5.4.3",
-        "slash": "2.0.0",
-        "source-map": "0.6.1",
-        "string-length": "2.0.0"
-      }
-    },
     "@jest/source-map": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.9.0.tgz",
@@ -1212,17 +1142,6 @@
         "@jest/console": "24.9.0",
         "@jest/types": "24.9.0",
         "@types/istanbul-lib-coverage": "2.0.1"
-      }
-    },
-    "@jest/test-sequencer": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.9.0.tgz",
-      "integrity": "sha512-6qqsU4o0kW1dvA95qfNog8v8gkRN9ph6Lz7r96IvZpHdNipP2cBcb07J1Z45mz/VIS01OHJ3pY8T5fUY38tg4A==",
-      "requires": {
-        "@jest/test-result": "24.9.0",
-        "jest-haste-map": "24.9.0",
-        "jest-runner": "24.9.0",
-        "jest-runtime": "24.9.0"
       }
     },
     "@jest/transform": {
@@ -2862,6 +2781,14 @@
         "node-releases": "1.1.49"
       }
     },
+    "bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "requires": {
+        "fast-json-stable-stringify": "2.1.0"
+      }
+    },
     "bser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -3234,38 +3161,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
-    },
-    "cliui": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-      "requires": {
-        "string-width": "3.1.0",
-        "strip-ansi": "5.2.0",
-        "wrap-ansi": "5.1.0"
-      },
-      "dependencies": {
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "requires": {
-            "emoji-regex": "7.0.3",
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "5.2.0"
-          }
-        }
-      }
     },
     "clone-deep": {
       "version": "0.2.4",
@@ -4126,11 +4021,6 @@
       "resolved": "https://registry.npmjs.org/destyle.css/-/destyle.css-1.0.11.tgz",
       "integrity": "sha512-BmI0mIqho8BQpdhylMTK0wkfeHs+z7J9U/Cri8Cf0W8odyLiuFUIXo3vlArEjUzIDKrVjQZz1xvXu8M2Nvfy2g=="
     },
-    "detect-newline": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-      "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
-    },
     "detect-node": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
@@ -4976,19 +4866,6 @@
             "is-extendable": "0.1.1"
           }
         }
-      }
-    },
-    "expect": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-24.9.0.tgz",
-      "integrity": "sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==",
-      "requires": {
-        "@jest/types": "24.9.0",
-        "ansi-styles": "3.2.1",
-        "jest-get-type": "24.9.0",
-        "jest-matcher-utils": "24.9.0",
-        "jest-message-util": "24.9.0",
-        "jest-regex-util": "24.9.0"
       }
     },
     "express": {
@@ -7075,111 +6952,6 @@
         }
       }
     },
-    "istanbul-lib-report": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
-      "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
-      "requires": {
-        "istanbul-lib-coverage": "2.0.5",
-        "make-dir": "2.1.0",
-        "supports-color": "6.1.0"
-      }
-    },
-    "istanbul-lib-source-maps": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
-      "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
-      "requires": {
-        "debug": "4.1.1",
-        "istanbul-lib-coverage": "2.0.5",
-        "make-dir": "2.1.0",
-        "rimraf": "2.6.3",
-        "source-map": "0.6.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        }
-      }
-    },
-    "istanbul-reports": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.7.tgz",
-      "integrity": "sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==",
-      "requires": {
-        "html-escaper": "2.0.0"
-      }
-    },
-    "jest": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-24.9.0.tgz",
-      "integrity": "sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==",
-      "requires": {
-        "import-local": "2.0.0",
-        "jest-cli": "24.9.0"
-      },
-      "dependencies": {
-        "jest-cli": {
-          "version": "24.9.0",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.9.0.tgz",
-          "integrity": "sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==",
-          "requires": {
-            "@jest/core": "24.9.0",
-            "@jest/test-result": "24.9.0",
-            "@jest/types": "24.9.0",
-            "chalk": "2.4.2",
-            "exit": "0.1.2",
-            "import-local": "2.0.0",
-            "is-ci": "2.0.0",
-            "jest-config": "24.9.0",
-            "jest-util": "24.9.0",
-            "jest-validate": "24.9.0",
-            "prompts": "2.3.1",
-            "realpath-native": "1.1.0",
-            "yargs": "13.3.0"
-          }
-        }
-      }
-    },
-    "jest-changed-files": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.9.0.tgz",
-      "integrity": "sha512-6aTWpe2mHF0DhL28WjdkO8LyGjs3zItPET4bMSeXU6T3ub4FPMw+mcOcbdGXQOAfmLcxofD23/5Bl9Z4AkFwqg==",
-      "requires": {
-        "@jest/types": "24.9.0",
-        "execa": "1.0.0",
-        "throat": "4.1.0"
-      }
-    },
-    "jest-config": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.9.0.tgz",
-      "integrity": "sha512-RATtQJtVYQrp7fvWg6f5y3pEFj9I+H8sWw4aKxnDZ96mob5i5SD6ZEGWgMLXQ4LE8UurrjbdlLWdUeo+28QpfQ==",
-      "requires": {
-        "@babel/core": "7.8.4",
-        "@jest/test-sequencer": "24.9.0",
-        "@jest/types": "24.9.0",
-        "babel-jest": "24.9.0",
-        "chalk": "2.4.2",
-        "glob": "7.1.6",
-        "jest-environment-jsdom": "24.9.0",
-        "jest-environment-node": "24.9.0",
-        "jest-get-type": "24.9.0",
-        "jest-jasmine2": "24.9.0",
-        "jest-regex-util": "24.9.0",
-        "jest-resolve": "24.9.0",
-        "jest-util": "24.9.0",
-        "jest-validate": "24.9.0",
-        "micromatch": "3.1.10",
-        "pretty-format": "24.9.0",
-        "realpath-native": "1.1.0"
-      }
-    },
     "jest-diff": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
@@ -7189,39 +6961,6 @@
         "diff-sequences": "24.9.0",
         "jest-get-type": "24.9.0",
         "pretty-format": "24.9.0"
-      }
-    },
-    "jest-docblock": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.9.0.tgz",
-      "integrity": "sha512-F1DjdpDMJMA1cN6He0FNYNZlo3yYmOtRUnktrT9Q37njYzC5WEaDdmbynIgy0L/IvXvvgsG8OsqhLPXTpfmZAA==",
-      "requires": {
-        "detect-newline": "2.1.0"
-      }
-    },
-    "jest-each": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.9.0.tgz",
-      "integrity": "sha512-ONi0R4BvW45cw8s2Lrx8YgbeXL1oCQ/wIDwmsM3CqM/nlblNCPmnC3IPQlMbRFZu3wKdQ2U8BqM6lh3LJ5Bsog==",
-      "requires": {
-        "@jest/types": "24.9.0",
-        "chalk": "2.4.2",
-        "jest-get-type": "24.9.0",
-        "jest-util": "24.9.0",
-        "pretty-format": "24.9.0"
-      }
-    },
-    "jest-environment-jsdom": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.9.0.tgz",
-      "integrity": "sha512-Zv9FV9NBRzLuALXjvRijO2351DRQeLYXtpD4xNvfoVFw21IOKNhZAEUKcbiEtjTkm2GsJ3boMVgkaR7rN8qetA==",
-      "requires": {
-        "@jest/environment": "24.9.0",
-        "@jest/fake-timers": "24.9.0",
-        "@jest/types": "24.9.0",
-        "jest-mock": "24.9.0",
-        "jest-util": "24.9.0",
-        "jsdom": "11.12.0"
       }
     },
     "jest-environment-jsdom-fourteen": {
@@ -7300,18 +7039,6 @@
         }
       }
     },
-    "jest-environment-node": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.9.0.tgz",
-      "integrity": "sha512-6d4V2f4nxzIzwendo27Tr0aFm+IXWa0XEUnaH6nU0FMaozxovt+sfRvh4J47wL1OvF83I3SSTu0XK+i4Bqe7uA==",
-      "requires": {
-        "@jest/environment": "24.9.0",
-        "@jest/fake-timers": "24.9.0",
-        "@jest/types": "24.9.0",
-        "jest-mock": "24.9.0",
-        "jest-util": "24.9.0"
-      }
-    },
     "jest-get-type": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
@@ -7334,38 +7061,6 @@
         "micromatch": "3.1.10",
         "sane": "4.1.0",
         "walker": "1.0.7"
-      }
-    },
-    "jest-jasmine2": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.9.0.tgz",
-      "integrity": "sha512-Cq7vkAgaYKp+PsX+2/JbTarrk0DmNhsEtqBXNwUHkdlbrTBLtMJINADf2mf5FkowNsq8evbPc07/qFO0AdKTzw==",
-      "requires": {
-        "@babel/traverse": "7.8.4",
-        "@jest/environment": "24.9.0",
-        "@jest/test-result": "24.9.0",
-        "@jest/types": "24.9.0",
-        "chalk": "2.4.2",
-        "co": "4.6.0",
-        "expect": "24.9.0",
-        "is-generator-fn": "2.1.0",
-        "jest-each": "24.9.0",
-        "jest-matcher-utils": "24.9.0",
-        "jest-message-util": "24.9.0",
-        "jest-runtime": "24.9.0",
-        "jest-snapshot": "24.9.0",
-        "jest-util": "24.9.0",
-        "pretty-format": "24.9.0",
-        "throat": "4.1.0"
-      }
-    },
-    "jest-leak-detector": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz",
-      "integrity": "sha512-tYkFIDsiKTGwb2FG1w8hX9V0aUb2ot8zY/2nFg087dUageonw1zrLMP4W6zsRO59dPkTSKie+D4rhMuP9nRmrA==",
-      "requires": {
-        "jest-get-type": "24.9.0",
-        "pretty-format": "24.9.0"
       }
     },
     "jest-matcher-utils": {
@@ -7424,103 +7119,10 @@
         "realpath-native": "1.1.0"
       }
     },
-    "jest-resolve-dependencies": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.9.0.tgz",
-      "integrity": "sha512-Fm7b6AlWnYhT0BXy4hXpactHIqER7erNgIsIozDXWl5dVm+k8XdGVe1oTg1JyaFnOxarMEbax3wyRJqGP2Pq+g==",
-      "requires": {
-        "@jest/types": "24.9.0",
-        "jest-regex-util": "24.9.0",
-        "jest-snapshot": "24.9.0"
-      }
-    },
-    "jest-runner": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.9.0.tgz",
-      "integrity": "sha512-KksJQyI3/0mhcfspnxxEOBueGrd5E4vV7ADQLT9ESaCzz02WnbdbKWIf5Mkaucoaj7obQckYPVX6JJhgUcoWWg==",
-      "requires": {
-        "@jest/console": "24.9.0",
-        "@jest/environment": "24.9.0",
-        "@jest/test-result": "24.9.0",
-        "@jest/types": "24.9.0",
-        "chalk": "2.4.2",
-        "exit": "0.1.2",
-        "graceful-fs": "4.2.3",
-        "jest-config": "24.9.0",
-        "jest-docblock": "24.9.0",
-        "jest-haste-map": "24.9.0",
-        "jest-jasmine2": "24.9.0",
-        "jest-leak-detector": "24.9.0",
-        "jest-message-util": "24.9.0",
-        "jest-resolve": "24.9.0",
-        "jest-runtime": "24.9.0",
-        "jest-util": "24.9.0",
-        "jest-worker": "24.9.0",
-        "source-map-support": "0.5.16",
-        "throat": "4.1.0"
-      }
-    },
-    "jest-runtime": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.9.0.tgz",
-      "integrity": "sha512-8oNqgnmF3v2J6PVRM2Jfuj8oX3syKmaynlDMMKQ4iyzbQzIG6th5ub/lM2bCMTmoTKM3ykcUYI2Pw9xwNtjMnw==",
-      "requires": {
-        "@jest/console": "24.9.0",
-        "@jest/environment": "24.9.0",
-        "@jest/source-map": "24.9.0",
-        "@jest/transform": "24.9.0",
-        "@jest/types": "24.9.0",
-        "@types/yargs": "13.0.8",
-        "chalk": "2.4.2",
-        "exit": "0.1.2",
-        "glob": "7.1.6",
-        "graceful-fs": "4.2.3",
-        "jest-config": "24.9.0",
-        "jest-haste-map": "24.9.0",
-        "jest-message-util": "24.9.0",
-        "jest-mock": "24.9.0",
-        "jest-regex-util": "24.9.0",
-        "jest-resolve": "24.9.0",
-        "jest-snapshot": "24.9.0",
-        "jest-util": "24.9.0",
-        "jest-validate": "24.9.0",
-        "realpath-native": "1.1.0",
-        "slash": "2.0.0",
-        "strip-bom": "3.0.0",
-        "yargs": "13.3.0"
-      }
-    },
     "jest-serializer": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.9.0.tgz",
       "integrity": "sha512-DxYipDr8OvfrKH3Kel6NdED3OXxjvxXZ1uIY2I9OFbGg+vUkkg7AGvi65qbhbWNPvDckXmzMPbK3u3HaDO49bQ=="
-    },
-    "jest-snapshot": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.9.0.tgz",
-      "integrity": "sha512-uI/rszGSs73xCM0l+up7O7a40o90cnrk429LOiK3aeTvfC0HHmldbd81/B7Ix81KSFe1lwkbl7GnBGG4UfuDew==",
-      "requires": {
-        "@babel/types": "7.8.3",
-        "@jest/types": "24.9.0",
-        "chalk": "2.4.2",
-        "expect": "24.9.0",
-        "jest-diff": "24.9.0",
-        "jest-get-type": "24.9.0",
-        "jest-matcher-utils": "24.9.0",
-        "jest-message-util": "24.9.0",
-        "jest-resolve": "24.9.0",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "pretty-format": "24.9.0",
-        "semver": "6.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        }
-      }
     },
     "jest-util": {
       "version": "24.9.0",
@@ -7539,19 +7141,6 @@
         "mkdirp": "0.5.1",
         "slash": "2.0.0",
         "source-map": "0.6.1"
-      }
-    },
-    "jest-validate": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.9.0.tgz",
-      "integrity": "sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==",
-      "requires": {
-        "@jest/types": "24.9.0",
-        "camelcase": "5.3.1",
-        "chalk": "2.4.2",
-        "jest-get-type": "24.9.0",
-        "leven": "3.1.0",
-        "pretty-format": "24.9.0"
       }
     },
     "jest-watch-typeahead": {
@@ -8039,6 +7628,11 @@
         "pify": "4.0.1",
         "semver": "5.7.1"
       }
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "makeerror": {
       "version": "1.0.11",
@@ -8608,18 +8202,6 @@
       "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
       "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA="
     },
-    "node-notifier": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz",
-      "integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
-      "requires": {
-        "growly": "1.3.0",
-        "is-wsl": "1.1.0",
-        "semver": "5.7.1",
-        "shellwords": "0.1.1",
-        "which": "1.3.1"
-      }
-    },
     "node-releases": {
       "version": "1.1.49",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.49.tgz",
@@ -8960,14 +8542,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
       "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
-    },
-    "p-each-series": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
-      "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
-      "requires": {
-        "p-reduce": "1.0.0"
-      }
     },
     "p-finally": {
       "version": "1.0.0",
@@ -10690,11 +10264,434 @@
         "workbox-webpack-plugin": "4.3.1"
       },
       "dependencies": {
+        "@jest/core": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/core/-/core-24.9.0.tgz",
+          "integrity": "sha512-Fogg3s4wlAr1VX7q+rhV9RVnUv5tD7VuWfYy1+whMiWUrvl7U3QJSJyWcDio9Lq2prqYsZaeTv2Rz24pWGkJ2A==",
+          "requires": {
+            "@jest/console": "24.9.0",
+            "@jest/reporters": "24.9.0",
+            "@jest/test-result": "24.9.0",
+            "@jest/transform": "24.9.0",
+            "@jest/types": "24.9.0",
+            "ansi-escapes": "3.2.0",
+            "chalk": "2.4.2",
+            "exit": "0.1.2",
+            "graceful-fs": "4.2.3",
+            "jest-changed-files": "24.9.0",
+            "jest-config": "24.9.0",
+            "jest-haste-map": "24.9.0",
+            "jest-message-util": "24.9.0",
+            "jest-regex-util": "24.9.0",
+            "jest-resolve": "24.9.0",
+            "jest-resolve-dependencies": "24.9.0",
+            "jest-runner": "24.9.0",
+            "jest-runtime": "24.9.0",
+            "jest-snapshot": "24.9.0",
+            "jest-util": "24.9.0",
+            "jest-validate": "24.9.0",
+            "jest-watcher": "24.9.0",
+            "micromatch": "3.1.10",
+            "p-each-series": "1.0.0",
+            "realpath-native": "1.1.0",
+            "rimraf": "2.6.3",
+            "slash": "2.0.0",
+            "strip-ansi": "5.2.0"
+          }
+        },
+        "@jest/reporters": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.9.0.tgz",
+          "integrity": "sha512-mu4X0yjaHrffOsWmVLzitKmmmWSQ3GGuefgNscUSWNiUNcEOSEQk9k3pERKEQVBb0Cnn88+UESIsZEMH3o88Gw==",
+          "requires": {
+            "@jest/environment": "24.9.0",
+            "@jest/test-result": "24.9.0",
+            "@jest/transform": "24.9.0",
+            "@jest/types": "24.9.0",
+            "chalk": "2.4.2",
+            "exit": "0.1.2",
+            "glob": "7.1.6",
+            "istanbul-lib-coverage": "2.0.5",
+            "istanbul-lib-instrument": "3.3.0",
+            "istanbul-lib-report": "2.0.8",
+            "istanbul-lib-source-maps": "3.0.6",
+            "istanbul-reports": "2.2.7",
+            "jest-haste-map": "24.9.0",
+            "jest-resolve": "24.9.0",
+            "jest-runtime": "24.9.0",
+            "jest-util": "24.9.0",
+            "jest-worker": "24.9.0",
+            "node-notifier": "5.4.3",
+            "slash": "2.0.0",
+            "source-map": "0.6.1",
+            "string-length": "2.0.0"
+          }
+        },
+        "@jest/test-sequencer": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.9.0.tgz",
+          "integrity": "sha512-6qqsU4o0kW1dvA95qfNog8v8gkRN9ph6Lz7r96IvZpHdNipP2cBcb07J1Z45mz/VIS01OHJ3pY8T5fUY38tg4A==",
+          "requires": {
+            "@jest/test-result": "24.9.0",
+            "jest-haste-map": "24.9.0",
+            "jest-runner": "24.9.0",
+            "jest-runtime": "24.9.0"
+          }
+        },
+        "ansi-escapes": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "requires": {
+            "string-width": "3.1.0",
+            "strip-ansi": "5.2.0",
+            "wrap-ansi": "5.1.0"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "detect-newline": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+          "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+        },
+        "expect": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-24.9.0.tgz",
+          "integrity": "sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==",
+          "requires": {
+            "@jest/types": "24.9.0",
+            "ansi-styles": "3.2.1",
+            "jest-get-type": "24.9.0",
+            "jest-matcher-utils": "24.9.0",
+            "jest-message-util": "24.9.0",
+            "jest-regex-util": "24.9.0"
+          }
+        },
         "fsevents": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
           "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
           "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "istanbul-lib-report": {
+          "version": "2.0.8",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+          "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
+          "requires": {
+            "istanbul-lib-coverage": "2.0.5",
+            "make-dir": "2.1.0",
+            "supports-color": "6.1.0"
+          }
+        },
+        "istanbul-lib-source-maps": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+          "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
+          "requires": {
+            "debug": "4.1.1",
+            "istanbul-lib-coverage": "2.0.5",
+            "make-dir": "2.1.0",
+            "rimraf": "2.6.3",
+            "source-map": "0.6.1"
+          }
+        },
+        "istanbul-reports": {
+          "version": "2.2.7",
+          "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.7.tgz",
+          "integrity": "sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==",
+          "requires": {
+            "html-escaper": "2.0.0"
+          }
+        },
+        "jest": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest/-/jest-24.9.0.tgz",
+          "integrity": "sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==",
+          "requires": {
+            "import-local": "2.0.0",
+            "jest-cli": "24.9.0"
+          },
+          "dependencies": {
+            "jest-cli": {
+              "version": "24.9.0",
+              "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.9.0.tgz",
+              "integrity": "sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==",
+              "requires": {
+                "@jest/core": "24.9.0",
+                "@jest/test-result": "24.9.0",
+                "@jest/types": "24.9.0",
+                "chalk": "2.4.2",
+                "exit": "0.1.2",
+                "import-local": "2.0.0",
+                "is-ci": "2.0.0",
+                "jest-config": "24.9.0",
+                "jest-util": "24.9.0",
+                "jest-validate": "24.9.0",
+                "prompts": "2.3.1",
+                "realpath-native": "1.1.0",
+                "yargs": "13.3.0"
+              }
+            }
+          }
+        },
+        "jest-changed-files": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.9.0.tgz",
+          "integrity": "sha512-6aTWpe2mHF0DhL28WjdkO8LyGjs3zItPET4bMSeXU6T3ub4FPMw+mcOcbdGXQOAfmLcxofD23/5Bl9Z4AkFwqg==",
+          "requires": {
+            "@jest/types": "24.9.0",
+            "execa": "1.0.0",
+            "throat": "4.1.0"
+          }
+        },
+        "jest-config": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.9.0.tgz",
+          "integrity": "sha512-RATtQJtVYQrp7fvWg6f5y3pEFj9I+H8sWw4aKxnDZ96mob5i5SD6ZEGWgMLXQ4LE8UurrjbdlLWdUeo+28QpfQ==",
+          "requires": {
+            "@babel/core": "7.8.4",
+            "@jest/test-sequencer": "24.9.0",
+            "@jest/types": "24.9.0",
+            "babel-jest": "24.9.0",
+            "chalk": "2.4.2",
+            "glob": "7.1.6",
+            "jest-environment-jsdom": "24.9.0",
+            "jest-environment-node": "24.9.0",
+            "jest-get-type": "24.9.0",
+            "jest-jasmine2": "24.9.0",
+            "jest-regex-util": "24.9.0",
+            "jest-resolve": "24.9.0",
+            "jest-util": "24.9.0",
+            "jest-validate": "24.9.0",
+            "micromatch": "3.1.10",
+            "pretty-format": "24.9.0",
+            "realpath-native": "1.1.0"
+          }
+        },
+        "jest-docblock": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.9.0.tgz",
+          "integrity": "sha512-F1DjdpDMJMA1cN6He0FNYNZlo3yYmOtRUnktrT9Q37njYzC5WEaDdmbynIgy0L/IvXvvgsG8OsqhLPXTpfmZAA==",
+          "requires": {
+            "detect-newline": "2.1.0"
+          }
+        },
+        "jest-each": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.9.0.tgz",
+          "integrity": "sha512-ONi0R4BvW45cw8s2Lrx8YgbeXL1oCQ/wIDwmsM3CqM/nlblNCPmnC3IPQlMbRFZu3wKdQ2U8BqM6lh3LJ5Bsog==",
+          "requires": {
+            "@jest/types": "24.9.0",
+            "chalk": "2.4.2",
+            "jest-get-type": "24.9.0",
+            "jest-util": "24.9.0",
+            "pretty-format": "24.9.0"
+          }
+        },
+        "jest-environment-jsdom": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.9.0.tgz",
+          "integrity": "sha512-Zv9FV9NBRzLuALXjvRijO2351DRQeLYXtpD4xNvfoVFw21IOKNhZAEUKcbiEtjTkm2GsJ3boMVgkaR7rN8qetA==",
+          "requires": {
+            "@jest/environment": "24.9.0",
+            "@jest/fake-timers": "24.9.0",
+            "@jest/types": "24.9.0",
+            "jest-mock": "24.9.0",
+            "jest-util": "24.9.0",
+            "jsdom": "11.12.0"
+          }
+        },
+        "jest-environment-node": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.9.0.tgz",
+          "integrity": "sha512-6d4V2f4nxzIzwendo27Tr0aFm+IXWa0XEUnaH6nU0FMaozxovt+sfRvh4J47wL1OvF83I3SSTu0XK+i4Bqe7uA==",
+          "requires": {
+            "@jest/environment": "24.9.0",
+            "@jest/fake-timers": "24.9.0",
+            "@jest/types": "24.9.0",
+            "jest-mock": "24.9.0",
+            "jest-util": "24.9.0"
+          }
+        },
+        "jest-jasmine2": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.9.0.tgz",
+          "integrity": "sha512-Cq7vkAgaYKp+PsX+2/JbTarrk0DmNhsEtqBXNwUHkdlbrTBLtMJINADf2mf5FkowNsq8evbPc07/qFO0AdKTzw==",
+          "requires": {
+            "@babel/traverse": "7.8.4",
+            "@jest/environment": "24.9.0",
+            "@jest/test-result": "24.9.0",
+            "@jest/types": "24.9.0",
+            "chalk": "2.4.2",
+            "co": "4.6.0",
+            "expect": "24.9.0",
+            "is-generator-fn": "2.1.0",
+            "jest-each": "24.9.0",
+            "jest-matcher-utils": "24.9.0",
+            "jest-message-util": "24.9.0",
+            "jest-runtime": "24.9.0",
+            "jest-snapshot": "24.9.0",
+            "jest-util": "24.9.0",
+            "pretty-format": "24.9.0",
+            "throat": "4.1.0"
+          }
+        },
+        "jest-leak-detector": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz",
+          "integrity": "sha512-tYkFIDsiKTGwb2FG1w8hX9V0aUb2ot8zY/2nFg087dUageonw1zrLMP4W6zsRO59dPkTSKie+D4rhMuP9nRmrA==",
+          "requires": {
+            "jest-get-type": "24.9.0",
+            "pretty-format": "24.9.0"
+          }
+        },
+        "jest-resolve-dependencies": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.9.0.tgz",
+          "integrity": "sha512-Fm7b6AlWnYhT0BXy4hXpactHIqER7erNgIsIozDXWl5dVm+k8XdGVe1oTg1JyaFnOxarMEbax3wyRJqGP2Pq+g==",
+          "requires": {
+            "@jest/types": "24.9.0",
+            "jest-regex-util": "24.9.0",
+            "jest-snapshot": "24.9.0"
+          }
+        },
+        "jest-runner": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.9.0.tgz",
+          "integrity": "sha512-KksJQyI3/0mhcfspnxxEOBueGrd5E4vV7ADQLT9ESaCzz02WnbdbKWIf5Mkaucoaj7obQckYPVX6JJhgUcoWWg==",
+          "requires": {
+            "@jest/console": "24.9.0",
+            "@jest/environment": "24.9.0",
+            "@jest/test-result": "24.9.0",
+            "@jest/types": "24.9.0",
+            "chalk": "2.4.2",
+            "exit": "0.1.2",
+            "graceful-fs": "4.2.3",
+            "jest-config": "24.9.0",
+            "jest-docblock": "24.9.0",
+            "jest-haste-map": "24.9.0",
+            "jest-jasmine2": "24.9.0",
+            "jest-leak-detector": "24.9.0",
+            "jest-message-util": "24.9.0",
+            "jest-resolve": "24.9.0",
+            "jest-runtime": "24.9.0",
+            "jest-util": "24.9.0",
+            "jest-worker": "24.9.0",
+            "source-map-support": "0.5.16",
+            "throat": "4.1.0"
+          }
+        },
+        "jest-runtime": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.9.0.tgz",
+          "integrity": "sha512-8oNqgnmF3v2J6PVRM2Jfuj8oX3syKmaynlDMMKQ4iyzbQzIG6th5ub/lM2bCMTmoTKM3ykcUYI2Pw9xwNtjMnw==",
+          "requires": {
+            "@jest/console": "24.9.0",
+            "@jest/environment": "24.9.0",
+            "@jest/source-map": "24.9.0",
+            "@jest/transform": "24.9.0",
+            "@jest/types": "24.9.0",
+            "@types/yargs": "13.0.8",
+            "chalk": "2.4.2",
+            "exit": "0.1.2",
+            "glob": "7.1.6",
+            "graceful-fs": "4.2.3",
+            "jest-config": "24.9.0",
+            "jest-haste-map": "24.9.0",
+            "jest-message-util": "24.9.0",
+            "jest-mock": "24.9.0",
+            "jest-regex-util": "24.9.0",
+            "jest-resolve": "24.9.0",
+            "jest-snapshot": "24.9.0",
+            "jest-util": "24.9.0",
+            "jest-validate": "24.9.0",
+            "realpath-native": "1.1.0",
+            "slash": "2.0.0",
+            "strip-bom": "3.0.0",
+            "yargs": "13.3.0"
+          }
+        },
+        "jest-snapshot": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.9.0.tgz",
+          "integrity": "sha512-uI/rszGSs73xCM0l+up7O7a40o90cnrk429LOiK3aeTvfC0HHmldbd81/B7Ix81KSFe1lwkbl7GnBGG4UfuDew==",
+          "requires": {
+            "@babel/types": "7.8.3",
+            "@jest/types": "24.9.0",
+            "chalk": "2.4.2",
+            "expect": "24.9.0",
+            "jest-diff": "24.9.0",
+            "jest-get-type": "24.9.0",
+            "jest-matcher-utils": "24.9.0",
+            "jest-message-util": "24.9.0",
+            "jest-resolve": "24.9.0",
+            "mkdirp": "0.5.1",
+            "natural-compare": "1.4.0",
+            "pretty-format": "24.9.0",
+            "semver": "6.3.0"
+          }
+        },
+        "jest-validate": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.9.0.tgz",
+          "integrity": "sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==",
+          "requires": {
+            "@jest/types": "24.9.0",
+            "camelcase": "5.3.1",
+            "chalk": "2.4.2",
+            "jest-get-type": "24.9.0",
+            "leven": "3.1.0",
+            "pretty-format": "24.9.0"
+          }
+        },
+        "node-notifier": {
+          "version": "5.4.3",
+          "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz",
+          "integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
+          "requires": {
+            "growly": "1.3.0",
+            "is-wsl": "1.1.0",
+            "semver": "5.7.1",
+            "shellwords": "0.1.1",
+            "which": "1.3.1"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+            }
+          }
+        },
+        "p-each-series": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
+          "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
+          "requires": {
+            "p-reduce": "1.0.0"
+          }
         },
         "resolve": {
           "version": "1.15.0",
@@ -10708,6 +10705,57 @@
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "requires": {
+            "emoji-regex": "7.0.3",
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "5.2.0"
+          }
+        },
+        "throat": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
+          "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo="
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "string-width": "3.1.0",
+            "strip-ansi": "5.2.0"
+          }
+        },
+        "yargs": {
+          "version": "13.3.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+          "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+          "requires": {
+            "cliui": "5.0.0",
+            "find-up": "3.0.0",
+            "get-caller-file": "2.0.5",
+            "require-directory": "2.1.1",
+            "require-main-filename": "2.0.0",
+            "set-blocking": "2.0.0",
+            "string-width": "3.1.0",
+            "which-module": "2.0.0",
+            "y18n": "4.0.0",
+            "yargs-parser": "13.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+          "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+          "requires": {
+            "camelcase": "5.3.1",
+            "decamelize": "1.2.0"
+          }
         }
       }
     },
@@ -12479,11 +12527,6 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
-    "throat": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
-      "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo="
-    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -12631,6 +12674,23 @@
       "dev": true,
       "requires": {
         "utf8-byte-length": "1.0.4"
+      }
+    },
+    "ts-jest": {
+      "version": "25.2.1",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-25.2.1.tgz",
+      "integrity": "sha512-TnntkEEjuXq/Gxpw7xToarmHbAafgCaAzOpnajnFC6jI7oo1trMzAHA04eWpc3MhV6+yvhE8uUBAmN+teRJh0A==",
+      "requires": {
+        "bs-logger": "0.2.6",
+        "buffer-from": "1.1.1",
+        "fast-json-stable-stringify": "2.1.0",
+        "json5": "2.1.1",
+        "lodash.memoize": "4.1.2",
+        "make-error": "1.3.6",
+        "mkdirp": "0.5.1",
+        "resolve": "1.15.1",
+        "semver": "5.7.1",
+        "yargs-parser": "16.1.0"
       }
     },
     "ts-pnp": {
@@ -13833,38 +13893,6 @@
         "microevent.ts": "0.1.1"
       }
     },
-    "wrap-ansi": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-      "requires": {
-        "ansi-styles": "3.2.1",
-        "string-width": "3.1.0",
-        "strip-ansi": "5.2.0"
-      },
-      "dependencies": {
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "requires": {
-            "emoji-regex": "7.0.3",
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "5.2.0"
-          }
-        }
-      }
-    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -13929,49 +13957,10 @@
         "@babel/runtime": "7.8.4"
       }
     },
-    "yargs": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
-      "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
-      "requires": {
-        "cliui": "5.0.0",
-        "find-up": "3.0.0",
-        "get-caller-file": "2.0.5",
-        "require-directory": "2.1.1",
-        "require-main-filename": "2.0.0",
-        "set-blocking": "2.0.0",
-        "string-width": "3.1.0",
-        "which-module": "2.0.0",
-        "y18n": "4.0.0",
-        "yargs-parser": "13.1.1"
-      },
-      "dependencies": {
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "requires": {
-            "emoji-regex": "7.0.3",
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "5.2.0"
-          }
-        }
-      }
-    },
     "yargs-parser": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
+      "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
       "requires": {
         "camelcase": "5.3.1",
         "decamelize": "1.2.0"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-scripts": "3.4.0",
+    "ts-jest": "^25.2.1",
     "typescript": "^3.7.5"
   },
   "devDependencies": {
@@ -25,6 +26,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
+    "test:watch": "react-scripts test --env=jsdom jest--watch",
     "eject": "react-scripts eject",
     "electron": "electron .",
     "edev": "ELECTRON_START_URL=http://localhost:3000 electron ."

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -2,8 +2,10 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
-  const { getByText } = render(<App />);
-  const linkElement = getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+describe('app', () => {
+  test('renders learn react link', () => {
+    const { queryAllByText } = render(<App />);
+    const elements = queryAllByText(/.*$.*/i);
+    expect(elements.length).toBeGreaterThan(0);
+  });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ function App() {
 
   const commands = (text: string) => {
     // TODO: split commands and evaluate flags after (pwd -> -L/-P)
+    // TODO: setup man page for pwd
     switch (text) {
       case 'hi':
       case 'hello':

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,7 @@ function App() {
       case 'hello':
         return 'hello to you too! 🐢';
       case 'pwd':
-        return pwd(cmdArgs, path, setPath, fs);
+        return pwd(cmdArgs, path, fs);
       default:
         return `tortoise: command not found: ${text}`;
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import Display from './components/Display';
 import Prompt from './components/Prompt';
 import './App.css';
+import { default as pwd } from './libs/pwd';
 const fs = window.require('fs');
 const { app } = window.require('electron').remote;
 const home: string = app.getPath('home');
@@ -14,32 +15,20 @@ export interface HistoryObject {
 function App() {
   const [history, setHistory] = useState<HistoryObject[]>([]);
   const [path, setPath] = useState<string>(
-    home + '/documents/desktop_application/terminal/symlink'
+    home + '/documents/desktop_application/symlink'
   );
 
   const commands = (text: string) => {
-    // TODO: split commands and evaluate flags after (pwd -> -L/-P)
     // TODO: setup man page for pwd
-    switch (text) {
+    const cmdArgs: string[] = text.split(' ');
+    const cmd: string | undefined = cmdArgs.shift();
+
+    switch (cmd) {
       case 'hi':
       case 'hello':
         return 'hello to you too! 🐢';
       case 'pwd':
-      case 'pwd -L':
-        return path;
-      case 'pwd -P':
-        let resolvedPath;
-        try {
-          const resolved = fs.readlinkSync(path);
-          const tmp = path.split('/');
-          tmp.pop();
-          tmp.push(resolved);
-          resolvedPath = tmp.join('/');
-        } catch (e) {
-          console.log(e);
-          resolvedPath = path;
-        }
-        return resolvedPath;
+        return pwd(cmdArgs, path, setPath, fs);
       default:
         return `tortoise: command not found: ${text}`;
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,11 @@ function App() {
   const commands = (text: string) => {
     // TODO: setup man page for pwd
     const cmdArgs: string[] = text.split(' ');
-    const cmd: string | undefined = cmdArgs.shift();
+    let cmd: string | undefined = cmdArgs.shift();
+
+    while (!cmd) {
+      cmd = cmdArgs.shift();
+    }
 
     switch (cmd) {
       case 'hi':

--- a/src/__mocks__/electron.js
+++ b/src/__mocks__/electron.js
@@ -1,0 +1,36 @@
+// __mocks__/fs.js
+'use strict';
+
+// const electron = jest.genMockFromModule('electron');
+// console.log(electron);
+// // electron.remote = jest.fn();
+// // electron.require = jest.fn();
+// // electron.app = jest.fn();
+// // electron.dialog = jest.fn();
+// // electron.match = jest.fn();
+
+// module.exports = electron;
+
+// export const electron = {
+//   require: jest.fn(),
+//   match: jest.fn(),
+//   app: jest.fn(),
+//   remote: jest.fn(),
+//   shell: jest.fn(),
+//   dialog: jest.fn(),
+// };
+
+export const remote = {
+  getCurrentWindow: jest.fn(),
+  dialog: jest.fn().mockImplementation(win => {
+    showOpenDialog: jest.fn(win => win); // if a sub-module method is needed
+  }),
+  app: {
+    getPath: jest.fn().mockReturnValue('/users/Ryan'),
+  },
+};
+
+// for the shell module above
+export const shell = {
+  openExternal: jest.fn(),
+};

--- a/src/__mocks__/fs.js
+++ b/src/__mocks__/fs.js
@@ -9,8 +9,8 @@ const fs = jest.genMockFromModule('fs');
 // `fs` APIs are used.
 let mockFiles = Object.create(null);
 function __setMockFiles(newMockFiles) {
-  mockFiles = Object.create(null);
-  for (const file in newMockFiles) {
+  // mockFiles = Object.create(null);
+  for (const file of newMockFiles) {
     const dir = path.dirname(file);
 
     if (!mockFiles[dir]) {
@@ -27,11 +27,13 @@ function readdirSync(directoryPath) {
 }
 // A custom version of `readlinkSync` that reads from the special mocked out
 // file list set via __setMockFiles
-function readlinkSync(directoryPath) {
-  if (directoryPath === 'symlink') {
-    return 'actualDirectory';
+function readlinkSync(path) {
+  const parts = path.split('/');
+  const curr = parts[parts.length - 1];
+  if (path === './users/Tortle/documents/symlink') {
+    return 'test';
   } else {
-    return directoryPath;
+    return curr;
   }
 }
 

--- a/src/__mocks__/fs.js
+++ b/src/__mocks__/fs.js
@@ -1,0 +1,42 @@
+// __mocks__/fs.js
+'use strict';
+
+const path = require('path');
+const fs = jest.genMockFromModule('fs');
+
+// This is a custom function that our tests can use during setup to specify
+// what the files on the "mock" filesystem should look like when any of the
+// `fs` APIs are used.
+let mockFiles = Object.create(null);
+function __setMockFiles(newMockFiles) {
+  mockFiles = Object.create(null);
+  for (const file in newMockFiles) {
+    const dir = path.dirname(file);
+
+    if (!mockFiles[dir]) {
+      mockFiles[dir] = [];
+    }
+    mockFiles[dir].push(path.basename(file));
+  }
+}
+
+// A custom version of `readdirSync` that reads from the special mocked out
+// file list set via __setMockFiles
+function readdirSync(directoryPath) {
+  return mockFiles[directoryPath] || [];
+}
+// A custom version of `readlinkSync` that reads from the special mocked out
+// file list set via __setMockFiles
+function readlinkSync(directoryPath) {
+  if (directoryPath === 'symlink') {
+    return 'actualDirectory';
+  } else {
+    return directoryPath;
+  }
+}
+
+fs.__setMockFiles = __setMockFiles;
+fs.readdirSync = readdirSync;
+fs.readlinkSync = readlinkSync;
+
+module.exports = fs;

--- a/src/components/Display.css
+++ b/src/components/Display.css
@@ -2,7 +2,6 @@
   width: 100%;
   height: min-content;
   overflow: scroll;
-  /* flex-grow: 1; */
   color: white;
   display: flex;
   flex-direction: column;

--- a/src/components/Prompt.css
+++ b/src/components/Prompt.css
@@ -1,11 +1,6 @@
 .prompt {
   width: 100%;
-  /* height: 100%; */
   resize: none;
   color: white;
-  flex-grow: 2;
-  /* -ms-word-break: break-all; */
-  /* These are technically the same, but use both, overflow works with ie/edge */
-  /* word-break: break-word;
-  overflow-wrap: break-word; */
+  flex-grow: 1;
 }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,2 @@
+// Ensure jest matchers are available for all test files
+import '@testing-library/jest-dom/extend-expect';

--- a/src/libs/__tests__/pwd.test.ts
+++ b/src/libs/__tests__/pwd.test.ts
@@ -1,0 +1,19 @@
+import { default as pwd } from '../pwd';
+const fs = require('fs');
+
+describe('pwd function', () => {
+  beforeAll(() => {
+    console.log(__dirname);
+    // fs.writeFileSync()
+  });
+
+  test('should return current path if no flags passed', () => {
+    // handles empty cmdArgs
+  });
+  test('', () => {
+    // handles invalid flags
+  });
+  test('', () => {
+    // resolves phys path or returns path arg
+  });
+});

--- a/src/libs/__tests__/pwd.test.ts
+++ b/src/libs/__tests__/pwd.test.ts
@@ -1,19 +1,60 @@
 import { default as pwd } from '../pwd';
-const fs = require('fs');
+import fs from '../../__mocks__/fs';
 
 describe('pwd function', () => {
+  const path = './users/Tortle/documents/symlink';
   beforeAll(() => {
-    console.log(__dirname);
-    // fs.writeFileSync()
+    fs.__setMockFiles(['users', 'Tortle', 'documents']);
+    // symlink is a shortcut to test, defined in fs mock
+    fs.__setMockFiles([
+      './users/Tortle/documents/test',
+      './users/Tortle/documents/symlink',
+    ]);
   });
 
-  test('should return current path if no flags passed', () => {
-    // handles empty cmdArgs
+  describe('with no flags or invalid flags', () => {
+    test('should return current path if no flags passed', () => {
+      const cmdArgs: string[] = [];
+      expect(pwd(cmdArgs, path, fs)).toEqual(path);
+    });
+
+    test('should return "too many arguments" if invalid flags exist', () => {
+      const cmdArgs: string[] = ['-L', '', '-', 'asdf', '-P', 'L'];
+      expect(pwd(cmdArgs, path, fs)).toEqual('pwd: too many arguments');
+    });
   });
-  test('', () => {
-    // handles invalid flags
+
+  describe('with valid flags containing -L', () => {
+    test('should return logical path if -L flag is passed', () => {
+      const cmdArgs: string[] = ['-L'];
+      expect(pwd(cmdArgs, path, fs)).toEqual(
+        './users/Tortle/documents/symlink'
+      );
+    });
+
+    test('should return logical path if -L is last flag in array of valid flags', () => {
+      const cmdArgs: string[] = ['-L', '', '-P', '-P', '', '-L'];
+      expect(pwd(cmdArgs, path, fs)).toEqual(
+        './users/Tortle/documents/symlink'
+      );
+    });
   });
-  test('', () => {
-    // resolves phys path or returns path arg
+
+  describe('with valid flags containing -P', () => {
+    test('should return physical path if -P is last flag in array of valid flags', () => {
+      const cmdArgs: string[] = ['-L', '', '-P', '-L', '-P'];
+      expect(pwd(cmdArgs, path, fs)).toEqual('./users/Tortle/documents/test');
+    });
+
+    test('should return resolved path if -P flag is passed with symbolic path', () => {
+      const cmdArgs: string[] = ['-P'];
+      expect(pwd(cmdArgs, path, fs)).toEqual('./users/Tortle/documents/test');
+    });
+
+    test('should return same path if -P flag is passed with physical path', () => {
+      const cmdArgs: string[] = ['-P'];
+      const path = './users/Tortle/documents/test';
+      expect(pwd(cmdArgs, path, fs)).toEqual('./users/Tortle/documents/test');
+    });
   });
 });

--- a/src/libs/pwd.ts
+++ b/src/libs/pwd.ts
@@ -11,7 +11,7 @@ export default function main(
   }
 
   if (!cmdArgs.length) return path;
-  const flags: validFlags = { '-L': '', '-P': '' };
+  const flags: validFlags = { '-L': '', '-P': '', '': '' };
   const validFlags = cmdArgs.every((f: string) => flags[f] !== undefined);
   if (!validFlags) return 'pwd: too many arguments';
 

--- a/src/libs/pwd.ts
+++ b/src/libs/pwd.ts
@@ -1,0 +1,58 @@
+export default function main(
+  cmdArgs: string[],
+  path: string,
+  setPath: (p: string) => void,
+  fs: {
+    readlinkSync: (path: string) => string;
+    readdirSync: (path: string) => string[];
+  }
+): string {
+  interface validFlags {
+    [flag: string]: string;
+  }
+
+  if (!cmdArgs.length) return path;
+  const flags: validFlags = { '-L': '', '-P': '' };
+  const validFlags = cmdArgs.every((f: string) => flags[f] !== undefined);
+  if (!validFlags) return 'pwd: too many arguments';
+
+  return resolveFlags(cmdArgs);
+
+  // helper functions
+  function resolveDir(p: string): string {
+    let resolvedPath;
+    try {
+      const resolved = fs.readlinkSync(p);
+      const tmp = p.split('/');
+      tmp.pop(); // pop off symlink
+      tmp.push(resolved); // replace with physical link
+      resolvedPath = tmp.join('/');
+    } catch (e) {
+      console.log(e);
+      resolvedPath = p;
+    }
+
+    return resolvedPath;
+  }
+
+  // /valid/sym/apples
+  //        sym => ./cats/whiskers
+  // -L => /valid/sym/apples
+  // -P => /
+  function resolveFlags(flags: string[]) {
+    let currPath: string = path;
+    let physPath: string | null = null;
+
+    for (let i = 0; i < flags.length; i++) {
+      // Fn only gets called if all flags are valid
+      if (flags[i] === '-P') {
+        if (!physPath) physPath = resolveDir(currPath);
+        currPath = physPath;
+      } else {
+        currPath = path;
+      }
+    }
+
+    return currPath;
+  }
+}

--- a/src/libs/pwd.ts
+++ b/src/libs/pwd.ts
@@ -1,7 +1,6 @@
 export default function main(
   cmdArgs: string[],
   path: string,
-  setPath: (p: string) => void,
   fs: {
     readlinkSync: (path: string) => string;
     readdirSync: (path: string) => string[];

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -3,3 +3,11 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom/extend-expect';
+import { remote } from './__mocks__/electron';
+
+global.window.require = function() {
+  return {
+    fs: jest.mock('fs'),
+    remote: { app: remote.app },
+  };
+};


### PR DESCRIPTION
Add functionality for checking multiple flags and handling white space. Mock fs readlinkSync and electron.remote.

Write tests for add-pwd:
- [x] tests that the logical path is returned when a user enters 'pwd' with no flags ('pwd' or 'pwd    ', etc.)
- [x] tests that 'too many arguments' is returned when a has multiple valid and invalid flags ('pwd -L -NM asdkjfln -P')
- [x] tests that the physical path is returned when user adds the -P flag
- [x] tests that the logical path is returned when user adds the -L flag
- [x] tests that multiple valid flags are evaluated left to right ('pwd -L -L -P -L -P')