### PR TITLE
Extract resolve dir

### DIFF
--- a/src/libs/__tests__/pwd.test.ts
+++ b/src/libs/__tests__/pwd.test.ts
@@ -1,5 +1,6 @@
 import { default as pwd } from '../pwd';
 import fs from '../../__mocks__/fs';
+import * as resolveDir from '../pathLib';
 
 describe('pwd function', () => {
   const path = './users/Tortle/documents/symlink';
@@ -41,6 +42,13 @@ describe('pwd function', () => {
   });
 
   describe('with valid flags containing -P', () => {
+    beforeAll(() => {
+      jest
+        .spyOn(resolveDir, 'resolveDir')
+        .mockImplementation(
+          (p: string) => './users/Tortle/documents/resolvedLink'
+        );
+    });
     test('should return physical path if -P is last flag in array of valid flags', () => {
       const cmdArgs: string[] = ['-L', '-P', '-L', '-P'];
       expect(pwd(cmdArgs, path, fs)).toEqual(

--- a/src/libs/__tests__/pwd.test.ts
+++ b/src/libs/__tests__/pwd.test.ts
@@ -1,6 +1,7 @@
 import { default as pwd } from '../pwd';
 import fs from '../../__mocks__/fs';
-import * as resolveDir from '../pathLib';
+jest.mock('../pathLib');
+const { resolveDir } = require('../pathLib');
 
 describe('pwd function', () => {
   const path = './users/Tortle/documents/symlink';
@@ -43,11 +44,15 @@ describe('pwd function', () => {
 
   describe('with valid flags containing -P', () => {
     beforeAll(() => {
-      jest
-        .spyOn(resolveDir, 'resolveDir')
-        .mockImplementation(
-          (p: string) => './users/Tortle/documents/resolvedLink'
-        );
+      // use if keeping track of call count to arg1
+      // jest
+      //   .spyOn(resolveDir, 'resolveDir')
+      //   .mockImplementation(
+      //     (p: string) => './users/Tortle/documents/resolvedLink'
+      //   );
+      resolveDir.mockImplementation(
+        (p: string) => './users/Tortle/documents/resolvedLink'
+      );
     });
     test('should return physical path if -P is last flag in array of valid flags', () => {
       const cmdArgs: string[] = ['-L', '-P', '-L', '-P'];

--- a/src/libs/pathLib.ts
+++ b/src/libs/pathLib.ts
@@ -14,7 +14,3 @@ export function resolveDir(p: string): string {
   console.log(resolvedPath, p);
   return resolvedPath;
 }
-
-const pathFns = { resolveDir };
-
-export default pathFns;

--- a/src/libs/pwd.ts
+++ b/src/libs/pwd.ts
@@ -1,3 +1,4 @@
+import { resolveDir } from './pathLib';
 import { ValidFlags } from '../common/types';
 
 export default function main(
@@ -14,23 +15,6 @@ export default function main(
   if (!validFlags) return 'pwd: too many arguments';
 
   return resolveFlags(cmdArgs);
-
-  // helper functions
-  function resolveDir(p: string): string {
-    let resolvedPath;
-    try {
-      const resolved = fs.readlinkSync(p);
-      const tmp = p.split('/');
-      tmp.pop(); // pop off symlink
-      tmp.push(resolved); // replace with physical link
-      resolvedPath = tmp.join('/');
-    } catch (e) {
-      console.log(e);
-      resolvedPath = p;
-    }
-
-    return resolvedPath;
-  }
 
   // /valid/sym/apples
   //        sym => ./cats/whiskers


### PR DESCRIPTION
Move resolveDir (resolves logical to physical paths) to its own pathLib file. It was moved since it is used in pwd and cd and likely other commands.